### PR TITLE
Dockerize building for local and Jenkins builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 Gemfile.lock
 *.cache
 .ruby-*
+*.swp

--- a/_config.yml
+++ b/_config.yml
@@ -19,5 +19,9 @@ defaults:
       type: blueprints
     values:
       layout: blueprint
-      
+
+# When building in Jenkins, this is where the Gems are installed
+# and we don't want them to be checked
+exclude: [bundle-install]
+
 # end of configuration

--- a/jenkins/linux/Dockerfile
+++ b/jenkins/linux/Dockerfile
@@ -1,0 +1,48 @@
+FROM fedora:23
+MAINTAINER "Konrad Kleine <kkleine@redhat.com>"
+ENV LANG=en_US.utf8
+
+# Some packages might seem weird but they are required by the
+# RVM installer
+RUN dnf install -y \
+      curl \
+      findutils \
+      graphviz \
+      java-1.8.0-openjdk-headless \
+      procps-ng \
+      python-blockdiag \
+      tar \
+      which \
+    && dnf clean all
+
+#----------------------------------------------------------
+# RVM setup
+# Inspired by https://rvm.io/rvm/security but not directly
+# copied as gpg needs to be gpg2 for instance.
+#----------------------------------------------------------
+
+# Two alternative methods for fetching the key for verification
+RUN gpg2 --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 \
+    || curl -sSL https://rvm.io/mpapis.asc | gpg2 --import -
+
+# Download the installer
+RUN curl -O https://raw.githubusercontent.com/rvm/rvm/master/binscripts/rvm-installer
+RUN curl -O https://raw.githubusercontent.com/rvm/rvm/master/binscripts/rvm-installer.asc
+
+# Verify the installer signature (might need `gpg2`), and if it validates...
+RUN gpg2 --verify rvm-installer.asc
+
+# Run RVM the installer
+RUN bash rvm-installer stable
+
+# Install Ruby through RVM and the bundle utility
+RUN bash -c "source /etc/profile.d/rvm.sh && rvm install 2.3.1 && gem install bundler"
+
+#----------------------------------------------------------
+# Misc.
+#----------------------------------------------------------
+
+# Mount source and build folders to these locations to get persitency
+VOLUME ["/source", "/build"]
+
+ENTRYPOINT ["/bin/bash"]

--- a/jenkins/linux/Makefile
+++ b/jenkins/linux/Makefile
@@ -1,0 +1,65 @@
+SOURCE_DIR := $(shell pwd)/../..
+DOCKER_IMAGE_DEVDOC := almighty-devdoc
+
+# The IS_JENKINS will be either "yes" or "no" depending on if
+# make is executed inside of Jenkins or locally.
+ifneq ($(BUILD_TAG),)
+	IS_JENKINS := "yes"
+	# If running in Jenkins we don't allow for interactively running the container
+	DOCKER_RUN_INTERACTIVE_SWITCH := 
+else 
+	IS_JENKINS := "no"
+	# If not running in Jenkins we allow for interactively running the container
+	DOCKER_RUN_INTERACTIVE_SWITCH :=  -i
+endif
+
+# The workspace environment is set by Jenkins and defaults to /tmp if not set
+WORKSPACE ?= /tmp
+BUILD_DIR := $(WORKSPACE)/almighty-devdoc-linux-build
+# The BUILD_TAG environment variable will be set by jenkins
+# to reflect jenkins-${JOB_NAME}-${BUILD_NUMBER}
+BUILD_TAG ?= almighty-devdoc-local-build
+CONTAINER_NAME := $(BUILD_TAG)
+
+# Call with $(call colorecho "hi" " there")
+define printlog
+	@tput setaf 6
+	@echo $1
+	@tput sgr0
+endef
+
+.PHONY: all
+all: build
+
+.PHONY: docker-image-devdoc
+docker-image-devdoc:
+	$(call printlog,"Building docker image $(DOCKER_IMAGE_DEVDOC)")
+	docker build -t $(DOCKER_IMAGE_DEVDOC) .
+
+.PHONY: build-dir
+build-dir:
+	$(call printlog,"Creating build directory $(BUILD_DIR)")
+	mkdir -p $(BUILD_DIR)
+
+.PHONY: clean
+clean:
+	$(call printlog,"Cleaning build directory $(BUILD_DIR)")
+	rm -rf $(BUILD_DIR)
+	
+.PHONY: build
+build: build-dir docker-image-devdoc
+	$(call prinlog,"Building with container $(CONTAINER_NAME) inside of $(BUILD_DIR)")
+	# TODO (kkleine) Remove interactive switch when running in Jenkins 
+	docker run \
+		-t \
+		$(DOCKER_RUN_INTERACTIVE_SWITCH) \
+		--rm \
+		--name="$(CONTAINER_NAME)" \
+		-v $(SOURCE_DIR):/source-dir:ro \
+		-v $(BUILD_DIR):/build-dir:rw \
+		-e USER=$(USER) \
+		-e USERID=$(shell id -u $(USER)) \
+		$(DOCKER_IMAGE_DEVDOC) \
+		/source-dir/jenkins/linux/build.sh /source-dir /build-dir
+
+

--- a/jenkins/linux/build.sh
+++ b/jenkins/linux/build.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+# Show all command prior to executing them
+set -x
+
+# Exit if a command fails
+set -e
+
+# Create user with same UID and name as the user that
+# started the container
+echo "Creating new user \"$USER\" with UID \"$USERID\""
+useradd -m ${USER} -u ${USERID}
+
+# Where the source is stored?
+# Take the value of the first and second argument or default
+# to /source and /build
+source_dir=${1:-/source}
+build_dir=${2:-/build}
+
+# Give all rights to users outside of the container
+function almighty_clean_up {
+  chown -R $USER ${build_dir} 
+}
+trap 'echo "SIGNAL received. Will clean up."; almighty_clean_up' SIGUSR1 SIGTERM SIGINT EXIT
+
+su $USER --command=" \
+cd ${source_dir} \
+&& cp -Rfp . ${build_dir} \
+&& chown -Rf $USER ${build_dir} \
+&& source /etc/profile.d/rvm.sh \
+&& cd ${build_dir} \
+&& bundle install --path=${build_dir}/bundle-install \
+&& bundle exec jekyll build \
+"
+


### PR DESCRIPTION
With this PR a user and a jenkins server can both build the project without the need to install a local development environment. The complete setup to and tools is covered by by a Docker image which blueprints are stored inside the code under `jenkins/linux/Dockerfile`.

This is what it takes:

``` bash
cd jenkins/linux
make
```

The only prerequisite is a working internet connection and an installation of Docker. Once could call this _software defined build process_ because all the CI server (Jenkins) does is executing a dumb set of commands and the rest is covered by the code.
## Details
- To avoid issues with permissions of volumes mounted into
  a container we create some a user that has the same UID and
  username as the user that starts a container. Under this user
  all commands to build the software and install dependencies
  are executed.
  - This allows build artefacts to be deleted by a local or a
    jenkins user once the container terminates.
  - As a precaution a bash trap ensures that everything is
    owned by the user that started the container
- To speed up iterative  builds I've moved the installation path
  for `bundle install` inside of build directoy that is mounted
  into the container on every start. If you don't call `make clean`
  the installed bundle will persist from each call to `make` to
  the next call to `make`.
