### PR TITLE
Provide automatically generated 'make help' target

### DIFF
--- a/jenkins/linux/Makefile
+++ b/jenkins/linux/Makefile
@@ -21,20 +21,32 @@ BUILD_DIR := $(WORKSPACE)/almighty-devdoc-linux-build
 BUILD_TAG ?= almighty-devdoc-local-build
 DOCKER_CONTAINER_NAME := $(BUILD_TAG)
 
+.PHONY: help
+# Shows all the commands and their description
+help:
+	@echo ""
+	@echo "Make file commands"
+	@echo "------------------"
+	@grep -Pzo "(?s)\.PHONY:(\N*)(.*)(^\1)" Makefile | grep -v Makefile | grep -o "\(.PHONY:.*\|^#.*\)" | sed -s 's/.PHONY:\s*/\n- /g' |sed -s 's/#/\t/g'
+
 .PHONY: all
+# Triggers the "build" target
 all: build
 
 .PHONY: docker-image-devdoc
+# Builds the docker image used to build the software
 docker-image-devdoc:
 	@echo "Building docker image $(DOCKER_IMAGE_DEVDOC)"
 	docker build -t $(DOCKER_IMAGE_DEVDOC) .
 
 .PHONY: build-dir
+# Creates the build directory
 build-dir:
 	@echo "Creating build directory $(BUILD_DIR)"
 	mkdir -p $(BUILD_DIR)
 
 .PHONY: clean-docker-container
+# Removes any existing container used to build the software (if any)
 clean-docker-container:
 	@echo "Removing container named \"$(DOCKER_CONTAINER_NAME)\" (if any)"
 ifneq ($(strip $(shell docker ps -qa --filter "name=$(DOCKER_CONTAINER_NAME)")),) 
@@ -44,14 +56,22 @@ else
 endif
 
 .PHONY: clean-build-dir
+# Removes the build directory
 clean-build-dir:
 	@echo "Cleaning build directory $(BUILD_DIR)"
 	rm -rf $(BUILD_DIR)
 
 .PHONY: clean
+# Triggers
+#  - clean-docker-container and
+#  - clean-build-dir
 clean: clean-docker-container clean-build-dir
 	
 .PHONY: build
+# Triggers 
+#  - build-dir and
+#  - docker-image-devdoc
+# and then spawns a docker container to build the software
 build: build-dir docker-image-devdoc
 	@echo "Building with container $(CONTAINER_NAME) inside of $(BUILD_DIR)"
 	# TODO (kkleine) Remove interactive switch when running in Jenkins 

--- a/jenkins/linux/Makefile
+++ b/jenkins/linux/Makefile
@@ -21,6 +21,10 @@ BUILD_DIR := $(WORKSPACE)/almighty-devdoc-linux-build
 BUILD_TAG ?= almighty-devdoc-local-build
 DOCKER_CONTAINER_NAME := $(BUILD_TAG)
 
+.PHONY: all
+# Triggers the "build" target
+all: build
+
 .PHONY: help
 # Shows all the commands and their description
 help:
@@ -28,10 +32,6 @@ help:
 	@echo "Make file commands"
 	@echo "------------------"
 	@grep -Pzo "(?s)\.PHONY:(\N*)(.*)(^\1)" Makefile | grep -v Makefile | grep -o "\(.PHONY:.*\|^#.*\)" | sed -s 's/.PHONY:\s*/\n- /g' |sed -s 's/#/\t/g'
-
-.PHONY: all
-# Triggers the "build" target
-all: build
 
 .PHONY: docker-image-devdoc
 # Builds the docker image used to build the software
@@ -73,7 +73,7 @@ clean: clean-docker-container clean-build-dir
 #  - docker-image-devdoc
 # and then spawns a docker container to build the software
 build: build-dir docker-image-devdoc
-	@echo "Building with container $(CONTAINER_NAME) inside of $(BUILD_DIR)"
+	@echo "Building with container $(DOCKER_CONTAINER_NAME) inside of $(BUILD_DIR)"
 	# TODO (kkleine) Remove interactive switch when running in Jenkins 
 	docker run \
 		-t \


### PR DESCRIPTION
When you enter `jenkins/linux` you find a `Makefile`. If you don't know what to do with it you can type `make help` to get this automatically generated output for all `.PHONY` targets that have comment lines between `.PHONY: mytarget` and `mytarget:`.

```
Make file commands
------------------

- help
     Shows all the commands and their description

- all
     Triggers the "build" target

- docker-image-devdoc
     Builds the docker image used to build the software

- build-dir
     Creates the build directory

- clean-docker-container
     Removes any existing container used to build the software (if any)

- clean-build-dir
     Removes the build directory

- clean
     Triggers
      - clean-docker-container and
      - clean-build-dir

- build
     Triggers 
      - build-dir and
      - docker-image-devdoc
     and then spawns a docker container to build the software
```
