### PR TITLE
Use relative images dir

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -24,7 +24,7 @@ asciidoctor:
     - source-highlighter=coderay
     - icons=font
     # single location for images (auto):
-    - imagesdir=/images
+    - imagesdir=images
     # single location for images (explicit):
     #- imagesdir=/images
     #- imagesoutdir={site-destination}/images


### PR DESCRIPTION
Why:
- images were not showing up when opening _site/*.html nor
  on the main website.

This change addreses the need by:
- using relative `images` instead of absolute `/images` in the config
  of asciidoc-diagrams
