### PR TITLE
Add missing link to strategy directory

### DIFF
--- a/ux/ux-overview.adoc
+++ b/ux/ux-overview.adoc
@@ -5,3 +5,4 @@ User Experience is broken down into three different areas:
 - link:discovery/discovery-overview.html[discovery]
 - link:design/design-overview.html[design]
 - link:usability-testing/usability-overview.html[usability testing]
+- link:strategy/strategy-overview.html[strategy]


### PR DESCRIPTION
As part of the addition of the strategy directory, this page was not updated. This fix is to address that issue on the devdoc.almighty.io site.
