### PR TITLE
WIP: Work item links: Design, Storage and REST API

### DIFF
--- a/_blueprints/work-item-links.adoc
+++ b/_blueprints/work-item-links.adoc
@@ -1,0 +1,73 @@
+= Work item links: Design, Storage and REST API
+:doctype: book
+:author: Konrad Kleine
+:toc: left
+:toc-title:Table of Contents
+:toclevels: 2
+:sectnums:
+:experimental:
+
+[abstract]
+= Abstract
+This document describes what the <<link,work item links>> and <<link-types,work
+item link types>> are, and how you can manipulate them via the various REST
+endpoints.
+
+We also explain the reasons we for why we chose the layout as it is planned or
+already implemented. This might involve a deep-dive into the way we store work
+item <<link-types,link types>> and <<link,links>> in our PostgreSQL database.
+
+[[introduction]]
+= Introduction
+
+A work item has different fields depending on its work item type. The work item
+types can be defined by an administrator.
+
+Depending on the a project's needs and the chosen workflow, an administrator can
+setup various work item types like for instance _epic_, _user-story_, _task_,
+and so forth. Those work items alone don't make much sense as long as they are
+not associated in a meaningful manner. For example, an _epic_ can have many
+_user-stories_ as children, which in turn can have one to many _tasks_. But a
+_user-story_ probably isn't going to have an _epic_ as a child. A work item of a
+type _bug_ might block another bug or is a duplicate of another bug.
+
+We call these associations between work items <<link,links>>.
+
+For a full list of terms, see the <<glossary>>.  
+
+include::../work-item-links/glossary.adoc[leveloffset=+1]
+
+include::../work-item-links/part.storage.adoc[]
+
+include::../work-item-links/part.rest.adoc[]
+
+include::../work-item-links/appendix.adoc[]
+
+include::../work-item-links/bibliography.adoc[]
+
+// [[fetch-all-link-types-response]]
+// .Fetch all link types response
+// [source,json]
+// ----
+// 200 OK
+// Content-type: application/vnd.linktypes+json, application/json, text, plain
+// 
+// [{
+//     "id": "1",
+//     "name": "user-story-task-link", 
+//     "desc": "Tasks can be associated with a user story.",
+//     "source": "system.user-story",
+//     "forwardName": "parent",
+//     "target": "system.task",
+//     "reverseName": "child"
+// },
+// {
+//     "id": "2",
+//     "name": "bug-blocker", 
+//     "desc": "The source bug shall prevent the target bug from being closed.",
+//     "source": "system.bug",
+//     "forwardName": "blocks",
+//     "target": "system.bug",
+//     "reverseName": "blocked by"
+// }]
+// ----

--- a/work-item-links/appendix.adoc
+++ b/work-item-links/appendix.adoc
@@ -1,0 +1,4 @@
+[appendix]
+= Open questions
+
+. Do we want to have <<link-type,link types>> per installation of the system or per project? 

--- a/work-item-links/bibliography.adoc
+++ b/work-item-links/bibliography.adoc
@@ -1,0 +1,5 @@
+[bibliography]
+= Bibliography
+
+- [[[jsonapi-spec]]] JSON API Specification
+  http://jsonapi.org/format/

--- a/work-item-links/glossary.adoc
+++ b/work-item-links/glossary.adoc
@@ -1,0 +1,76 @@
+[[glossary]]
+[glossary]
+= Glossary
+
+The following subsections list important terms when talking about work item links.
+
+[glossary]
+[[link,link]]
+link::
+A link describes a _bidrectional_ relationship between two work items. That
+means there's a defined <<source,source>> work item and a <<target,target>> work
+item in a link. Their work item type is relevant. This allows us to create a
+parent-child relationship among work items, like the one between an _epic_ and a
+_user-story_, like we've explained in the above paragraph.
++
+To realize this concept of a relationship between a source and a target in the
+underlying storage, we will have to define a <<link-type,link type>>.
+
+[[link-type,link type]]
+link type::
+A link type defines what work item types can be linked together and how their
+relationship can be described.
+
+[[link-category,link category]]
+link category::
+A <<link-type>> can have a category like `"system"`, `"extension"`, or `"user"`.
++
+IMPORTANT: A user can only create, update, or delete, links in the `"user"`
+<<link-category>>. Needless to say that a user can only create, update, or
+delete <<link-type,link types>> with the link category `"user"`. This is a
+security mechanism to prevent the user from breaking the system.
+
+[[source,source]]
+source::
+The source defines where the relationship between two work items starts. It
+given as a work item ID. The type of work item that can be used as a source is
+defined by the <<source-type>>. Read more about this in
+<<storage-of-link-types>>.
+
+[[source-type,source type]]
+source type::
+The <<source>> type specifies the type of work item that can be used as a
+<<source>>.
+
+[[target,target]]
+target::
+The target defines where the relationship between two work items ends. It is
+given as a work item ID. The type of work item that can be used as a target is
+defined by the <<target-type>>. Read more about this in <<storage-of-link-types>>.
+
+[[target-type,target type]]
+target type::
+The <<target>> type specifies the type of work item that can be used as a
+<<target>>.
+
+[[forward-name,forward name]]
+forward name::
+The forward oriented path from <<source>> _to_ <<target>> is described with the
+_forward name_. For example, if a bug _blocks_ a user story, the forward name is
+`"blocks"`. See also <<reverse-name>>.
+
+[[reverse-name,reverse name]]
+reverse name::
+The backwards oriented path from <<target>> _to_ <<source>> is described with
+the _reverse name_. For example, if a bug _blocks_ a user story, the reverse
+name name is `"blocked by"` as in: a user story is _blocked by_ a bug. See also
+<<forward-name>>.
+
+[[link-comment,link comment]]
+link comment::
+A link comment is an optional string field on a <<link>> that allows the creator
+of a <<link>> to further specify the relationship. For example, think of a
+fictional `'test'` subsystem that wants to create a link between one of its
+`test-result` work items and a `pull-request` work item. For convenience, it
+makes sense to specify a string like: `"The code from pull request X passed the
+tests in test Y."`.

--- a/work-item-links/linkcategories/examples/linkcategories-create.req.txt
+++ b/work-item-links/linkcategories/examples/linkcategories-create.req.txt
@@ -1,0 +1,15 @@
+POST http://example.com/api/linkcategories/ HTTP/1.1
+Content-Type: application/vnd.api+json
+Accept: application/vnd.api+json
+
+{
+  "data": {
+    "meta": { "comment": "Note, that the 'id' field is optional for a create request." },
+    "id": "6c5610be-30b2-4880-9fec-81e4f8e4fd76",
+    "type": "linkcategories",
+    "attributes": {
+      "name": "test",
+      "title": "This category is reserved for link types that belong to the 'test' subsystem."
+    }
+  }
+}

--- a/work-item-links/linkcategories/examples/linkcategories-create.res.txt
+++ b/work-item-links/linkcategories/examples/linkcategories-create.res.txt
@@ -1,0 +1,17 @@
+HTTP/1.1 201 Created
+Location: http://example.com/api/linkcategories/6c5610be-30b2-4880-9fec-81e4f8e4fd76
+Content-Type: application/vnd.api+json
+
+{
+  "data": {
+    "type": "linkcategories",
+    "id": "6c5610be-30b2-4880-9fec-81e4f8e4fd76",
+    "attributes": {
+      "name": "test",
+      "title": "This category is reserved for link types that belong to the 'test' subsystem."
+    },
+    "links": {
+      "self": "http://example.com/api/linkcategories/6c5610be-30b2-4880-9fec-81e4f8e4fd76"
+    }
+  }
+}

--- a/work-item-links/linkcategories/examples/linkcategories-delete.req.txt
+++ b/work-item-links/linkcategories/examples/linkcategories-delete.req.txt
@@ -1,0 +1,2 @@
+DELETE http://example.com/api/linkcategories/6c5610be-30b2-4880-9fec-81e4f8e4fd76 HTTP/1.1
+Accept: application/vnd.api+json

--- a/work-item-links/linkcategories/examples/linkcategories-read-single.req.get
+++ b/work-item-links/linkcategories/examples/linkcategories-read-single.req.get
@@ -1,0 +1,2 @@
+GET http://example.com/api/linkcategories/6c5610be-30b2-4880-9fec-81e4f8e4fd76 HTTP/1.1
+Accept: application/vnd.api+json

--- a/work-item-links/linkcategories/examples/linkcategories-update.req.txt
+++ b/work-item-links/linkcategories/examples/linkcategories-update.req.txt
@@ -1,0 +1,13 @@
+PATCH http://example.com/api/linkcategories/6c5610be-30b2-4880-9fec-81e4f8e4fd76 HTTP/1.1
+Content-Type: application/vnd.api+json
+Accept: application/vnd.api+json
+
+{
+  "data": {
+    "type": "linkcategories",
+    "id": "6c5610be-30b2-4880-9fec-81e4f8e4fd76",
+    "attributes": {
+      "title": "This is a new title for the link category with the name 'test'."
+    }
+  }
+}

--- a/work-item-links/linkcategories/index.adoc
+++ b/work-item-links/linkcategories/index.adoc
@@ -1,0 +1,7 @@
+[[link-category-resource]]
+= Link category resource
+
+include::linkcategories-create.adoc[leveloffset=+1]
+include::linkcategories-read.adoc[leveloffset=+1]
+include::linkcategories-update.adoc[leveloffset=+1]
+include::linkcategories-delete.adoc[leveloffset=+1]

--- a/work-item-links/linkcategories/linkcategories-create.adoc
+++ b/work-item-links/linkcategories/linkcategories-create.adoc
@@ -1,0 +1,37 @@
+[[create-link-category]]
+= Create link category
+
+A normal user should not be allowed to create <<link-category,link categories>>.
+This is a task that the system or an extension or plugin to the system should
+only be allowed to execute. 
+
+[[create-link-category-request]]
+== Request
+
+In order to create a <<link-category>> for a fictional `'test'` subsystem,
+you would have to request it this way:
+
+[source,json]
+----
+include::examples/linkcategories-create.req.txt[]
+----
+
+== Responses
+
+This section contains possible responses for a
+<<create-link-category-request,link category creation request>>.
+
+link:http://jsonapi.org/format/#crud-creating-responses-201[`201 Created`]::
+[source,json]
+----
+include::examples/linkcategories-create.res.txt[]
+----
+
+These are also possible return codes:
+
+* link:http://jsonapi.org/format/#crud-creating-responses-202[`202 Accepted`]
+* link:http://jsonapi.org/format/#crud-creating-responses-204[`204 No Content`]
+* link:http://jsonapi.org/format/#crud-creating-responses-403[`403 Forbidden`]
+* link:http://jsonapi.org/format/#crud-creating-responses-404[`404 Not Found`]
+* link:http://jsonapi.org/format/#crud-creating-responses-409[`409 Conflict`]
+* link:http://jsonapi.org/format/#crud-creating-responses-other[Other Responses]

--- a/work-item-links/linkcategories/linkcategories-delete.adoc
+++ b/work-item-links/linkcategories/linkcategories-delete.adoc
@@ -1,0 +1,22 @@
+[[delete-link-category]]
+= Delete link category
+
+[[delete-link-category-request]]
+== Request
+
+In order to delete <<link-category>>, execute this request.
+
+[source]
+----
+include::examples/linkcategories-delete.req.txt[]
+----
+
+== Responses
+
+These are possible return codes:
+
+* link:http://jsonapi.org/format/#crud-deleting-responses-202[`202 Accepted`]
+* link:http://jsonapi.org/format/#crud-deleting-responses-204[`204 No Content`]
+* link:http://jsonapi.org/format/#crud-deleting-responses-200[`200 OK`]
+* link:http://jsonapi.org/format/#crud-deleting-responses-404[`404 Not Found`]
+* link:http://jsonapi.org/format/#crud-deleting-responses-other[Other Responses]

--- a/work-item-links/linkcategories/linkcategories-read.adoc
+++ b/work-item-links/linkcategories/linkcategories-read.adoc
@@ -1,0 +1,22 @@
+[[read-link-category]]
+= Read link category
+
+[[read-link-category-request]]
+== Request
+
+In order to read a single <<link-category>>, execute this request.
+
+[source]
+----
+include::examples/linkcategories-read-single.req.get[]
+----
+
+More information on fetching a resource please take a look at the JSON API
+section link:http://jsonapi.org/format/#fetching[here].
+
+== Responses
+
+These are possible return codes:
+
+* link:http://jsonapi.org/format/#fetching-resources-responses-200[`200 OK`]
+* link:http://jsonapi.org/format/#fetching-resources-responses-404[`404 Not Found`]

--- a/work-item-links/linkcategories/linkcategories-update.adoc
+++ b/work-item-links/linkcategories/linkcategories-update.adoc
@@ -1,0 +1,28 @@
+[[update-link-category]]
+= Update link category
+
+[[update-link-category-request]]
+== Request
+
+In order to update <<link-category>>, execute this request.
+
+[source,json]
+----
+include::examples/linkcategories-update.req.txt[]
+----
+
+For more information on updating a resource and not including all attributes, 
+please take a look at the JSON API section
+link:http://jsonapi.org/format/#crud-updating-resource-attributes[here].
+
+== Responses
+
+These are possible return codes:
+
+* link:http://jsonapi.org/format/#crud-updating-responses-202[`202 Accepted`]
+* link:http://jsonapi.org/format/#crud-updating-responses-200[`200 OK`]
+* link:http://jsonapi.org/format/#crud-updating-responses-204[`204 No Content`]
+* link:http://jsonapi.org/format/#crud-updating-responses-403[`403 Forbidden`]
+* link:http://jsonapi.org/format/#crud-updating-responses-404[`404 Not Found`]
+* link:http://jsonapi.org/format/#crud-updating-responses-409[`409 Conflict`]
+* link:http://jsonapi.org/format/#crud-updating-responses-other[Other Responses]

--- a/work-item-links/links/examples/links-create.req.txt
+++ b/work-item-links/links/examples/links-create.req.txt
@@ -1,0 +1,23 @@
+POST http://example.com/api/links/ HTTP/1.1
+Content-Type: application/vnd.api+json
+Accept: application/vnd.api+json
+
+{
+  "data": {
+    "meta": { "comment": "Note, that the 'id' field is optional for a create request." },
+    "id": "c6923e37-5111-4972-8397-a0009c8425a5",
+    "type": "links",
+    "attributes": {
+      "meta": { "comment": "The source and target UUIDs are purely fictional." },
+      "source": "6ae6cb8f-dfc6-4217-b057-1e8639042cb5",
+      "target": "82e24c1b-af7b-4612-97da-4b9cb8e0058b",
+      "comment": "The code from pull request X passed the tests in test Y."
+    },
+    "relationships": {
+      "link_type": {
+        "meta": { "comment": "See the creation of link types for what this ID means" },
+        "data": { "type": "linktypes", "id": "40bbdd3d-8b5d-4fd6-ac90-7236b669af04" }
+      }
+    }
+  }
+}

--- a/work-item-links/links/examples/links-create.res.txt
+++ b/work-item-links/links/examples/links-create.res.txt
@@ -1,0 +1,27 @@
+HTTP/1.1 201 Created
+Location: http://example.com/api/links/c6923e37-5111-4972-8397-a0009c8425a5
+Content-Type: application/vnd.api+json
+
+{
+  "data": {
+    "type": "linktypes",
+    "id": "c6923e37-5111-4972-8397-a0009c8425a5",
+    "attributes": {
+      "source": "6ae6cb8f-dfc6-4217-b057-1e8639042cb5",
+      "target": "82e24c1b-af7b-4612-97da-4b9cb8e0058b",
+      "comment": "The code from pull request X passed the tests in test Y."
+    },
+    "relationships": {
+      "link_type": {
+        "data": { "type": "linktypes", "id": "40bbdd3d-8b5d-4fd6-ac90-7236b669af04" },
+        "links": {
+          "self": "http://example.com/api/links/c6923e37-5111-4972-8397-a0009c8425a5/relationships/link_type",
+          "related": "http://example.com/api/links/c6923e37-5111-4972-8397-a0009c8425a5/link_type"
+        }
+      }
+    },
+    "links": {
+      "self": "http://example.com/api/links/c6923e37-5111-4972-8397-a0009c8425a5"
+    }
+  }
+}

--- a/work-item-links/links/examples/links-delete.req.txt
+++ b/work-item-links/links/examples/links-delete.req.txt
@@ -1,0 +1,2 @@
+DELETE http://example.com/api/links/c6923e37-5111-4972-8397-a0009c8425a5 HTTP/1.1
+Accept: application/vnd.api+json

--- a/work-item-links/links/examples/links-read-single.req.get
+++ b/work-item-links/links/examples/links-read-single.req.get
@@ -1,0 +1,2 @@
+GET http://example.com/api/links/c6923e37-5111-4972-8397-a0009c8425a5 HTTP/1.1
+Accept: application/vnd.api+json

--- a/work-item-links/links/examples/links-update.req.txt
+++ b/work-item-links/links/examples/links-update.req.txt
@@ -1,0 +1,13 @@
+PATCH http://example.com/api/links/c6923e37-5111-4972-8397-a0009c8425a5 HTTP/1.1
+Content-Type: application/vnd.api+json
+Accept: application/vnd.api+json
+
+{
+  "data": {
+    "type": "links",
+    "id": "c6923e37-5111-4972-8397-a0009c8425a5",
+    "attributes": {
+      "comment": "This is a new comment for the link with id c6923e37-5111-4972-8397-a0009c8425a5"
+    }
+  }
+}

--- a/work-item-links/links/index.adoc
+++ b/work-item-links/links/index.adoc
@@ -1,0 +1,7 @@
+[[link-resource]]
+= Link resource
+
+include::links-create.adoc[leveloffset=+1]
+include::links-read.adoc[leveloffset=+1]
+include::links-update.adoc[leveloffset=+1]
+include::links-delete.adoc[leveloffset=+1]

--- a/work-item-links/links/links-create.adoc
+++ b/work-item-links/links/links-create.adoc
@@ -1,0 +1,33 @@
+[[create-link]]
+= Create link
+
+[[create-link-request]]
+== Request
+
+In order to create a <<link>> of the <<link-type>> with the name
+`'tested-by-link-type'`, you would have to request it this way:
+
+[source,json]
+----
+include::examples/links-create.req.txt[]
+----
+
+== Responses
+
+This section contains possible responses for a
+<<create-link-request,link creation request>>.
+
+link:http://jsonapi.org/format/#crud-creating-responses-201[`201 Created`]::
+[source,json]
+----
+include::examples/links-create.res.txt[]
+----
+
+These are also possible return codes:
+
+* link:http://jsonapi.org/format/#crud-creating-responses-202[`202 Accepted`]
+* link:http://jsonapi.org/format/#crud-creating-responses-204[`204 No Content`]
+* link:http://jsonapi.org/format/#crud-creating-responses-403[`403 Forbidden`]
+* link:http://jsonapi.org/format/#crud-creating-responses-404[`404 Not Found`]
+* link:http://jsonapi.org/format/#crud-creating-responses-409[`409 Conflict`]
+* link:http://jsonapi.org/format/#crud-creating-responses-other[Other Responses]

--- a/work-item-links/links/links-delete.adoc
+++ b/work-item-links/links/links-delete.adoc
@@ -1,0 +1,22 @@
+[[delete-link]]
+= Delete link
+
+[[delete-link-request]]
+== Request
+
+In order to delete <<link>>, execute this request.
+
+[source]
+----
+include::examples/links-delete.req.txt[]
+----
+
+== Responses
+
+These are possible return codes:
+
+* link:http://jsonapi.org/format/#crud-deleting-responses-202[`202 Accepted`]
+* link:http://jsonapi.org/format/#crud-deleting-responses-204[`204 No Content`]
+* link:http://jsonapi.org/format/#crud-deleting-responses-200[`200 OK`]
+* link:http://jsonapi.org/format/#crud-deleting-responses-404[`404 Not Found`]
+* link:http://jsonapi.org/format/#crud-deleting-responses-other[Other Responses]

--- a/work-item-links/links/links-read.adoc
+++ b/work-item-links/links/links-read.adoc
@@ -1,0 +1,22 @@
+[[read-link]]
+= Read link
+
+[[read-link-request]]
+== Request
+
+In order to read a single <<link>>, execute this request.
+
+[source]
+----
+include::examples/links-read-single.req.get[]
+----
+
+More information on fetching a resource please take a look at the JSON API
+section link:http://jsonapi.org/format/#fetching[here].
+
+== Responses
+
+These are possible return codes:
+
+* link:http://jsonapi.org/format/#fetching-resources-responses-200[`200 OK`]
+* link:http://jsonapi.org/format/#fetching-resources-responses-404[`404 Not Found`]

--- a/work-item-links/links/links-update.adoc
+++ b/work-item-links/links/links-update.adoc
@@ -1,0 +1,28 @@
+[[update-link]]
+= Update link
+
+[[update-link-request]]
+== Request
+
+In order to update <<link>>, execute this request.
+
+[source,json]
+----
+include::examples/links-update.req.txt[]
+----
+
+For more information on updating a resource and not including all attributes, 
+please take a look at the JSON API section
+link:http://jsonapi.org/format/#crud-updating-resource-attributes[here].
+
+== Responses
+
+These are possible return codes:
+
+* link:http://jsonapi.org/format/#crud-updating-responses-202[`202 Accepted`]
+* link:http://jsonapi.org/format/#crud-updating-responses-200[`200 OK`]
+* link:http://jsonapi.org/format/#crud-updating-responses-204[`204 No Content`]
+* link:http://jsonapi.org/format/#crud-updating-responses-403[`403 Forbidden`]
+* link:http://jsonapi.org/format/#crud-updating-responses-404[`404 Not Found`]
+* link:http://jsonapi.org/format/#crud-updating-responses-409[`409 Conflict`]
+* link:http://jsonapi.org/format/#crud-updating-responses-other[Other Responses]

--- a/work-item-links/linktypes/examples/linktypes-create.req.txt
+++ b/work-item-links/linktypes/examples/linktypes-create.req.txt
@@ -1,0 +1,25 @@
+POST http://example.com/api/linktypes/ HTTP/1.1
+Content-Type: application/vnd.api+json
+Accept: application/vnd.api+json
+
+{
+  "data": {
+    "meta": { "comment": "Note, that the 'id' field is optional for a create request." },
+    "id": "40bbdd3d-8b5d-4fd6-ac90-7236b669af04",
+    "type": "linktypes",
+    "attributes": {
+      "name": "tested-by-link-type",
+      "description": "A test work item can 'test' if a the code in a pull request passes the tests.",
+      "source_type": "test-workitemtype",
+      "target_type": "pull-request-workitemttype",
+      "forward_name": "tests",
+      "reverse_name": "tested by"
+    },
+    "relationships": {
+      "link_category": {
+        "meta": { "comment": "See the creation of link categories for what this ID means" },
+        "data": { "type": "link_category", "id": "6c5610be-30b2-4880-9fec-81e4f8e4fd76" }
+      }
+    }
+  }
+}

--- a/work-item-links/linktypes/examples/linktypes-create.res.txt
+++ b/work-item-links/linktypes/examples/linktypes-create.res.txt
@@ -1,0 +1,31 @@
+HTTP/1.1 201 Created
+Location: http://example.com/api/linktypes/40bbdd3d-8b5d-4fd6-ac90-7236b669af04
+Content-Type: application/vnd.api+json
+
+{
+  "data": {
+    "type": "linktypes",
+    "id": "40bbdd3d-8b5d-4fd6-ac90-7236b669af04",
+    "attributes": {
+      "name": "tested-by-link-type",
+      "description": "A test work item can 'test' if a the code in a pull request passes the tests.",
+      "source_type": "test-workitemtype",
+      "target_type": "pull-request-workitemttype",
+      "forward_name": "tests",
+      "reverse_name": "tested by"
+    },
+    "relationships": {
+      "link_category": {
+        "meta": { "comment": "See the creation of link categories for what this ID means" },
+        "data": { "type": "link_category", "id": "6c5610be-30b2-4880-9fec-81e4f8e4fd76" },
+        "links": {
+          "self": "http://example.com/api/linktypes/40bbdd3d-8b5d-4fd6-ac90-7236b669af04/relationships/link_category",
+          "related": "http://example.com/api/linktypes/40bbdd3d-8b5d-4fd6-ac90-7236b669af04/link_category"
+        }
+      }
+    },
+    "links": {
+      "self": "http://example.com/api/linktypes/40bbdd3d-8b5d-4fd6-ac90-7236b669af04"
+    }
+  }
+}

--- a/work-item-links/linktypes/examples/linktypes-delete.req.txt
+++ b/work-item-links/linktypes/examples/linktypes-delete.req.txt
@@ -1,0 +1,2 @@
+DELETE http://example.com/api/linktypes/40bbdd3d-8b5d-4fd6-ac90-7236b669af04 HTTP/1.1
+Accept: application/vnd.api+json

--- a/work-item-links/linktypes/examples/linktypes-read-single.req.get
+++ b/work-item-links/linktypes/examples/linktypes-read-single.req.get
@@ -1,0 +1,2 @@
+GET http://example.com/api/linktypes/6c5610be-30b2-4880-9fec-81e4f8e4fd76 HTTP/1.1
+Accept: application/vnd.api+json

--- a/work-item-links/linktypes/examples/linktypes-update.req.txt
+++ b/work-item-links/linktypes/examples/linktypes-update.req.txt
@@ -1,0 +1,13 @@
+PATCH http://example.com/api/linktypes/40bbdd3d-8b5d-4fd6-ac90-7236b669af04 HTTP/1.1
+Content-Type: application/vnd.api+json
+Accept: application/vnd.api+json
+
+{
+  "data": {
+    "type": "linktypes",
+    "id": "40bbdd3d-8b5d-4fd6-ac90-7236b669af04",
+    "attributes": {
+      "title": "This is a new title for the link type with the name 'tested-by-link-type'."
+    }
+  }
+}

--- a/work-item-links/linktypes/index.adoc
+++ b/work-item-links/linktypes/index.adoc
@@ -1,0 +1,7 @@
+[[link-type-resource]]
+= Link type resource
+
+include::linktypes-create.adoc[leveloffset=+1]
+include::linktypes-read.adoc[leveloffset=+1]
+include::linktypes-update.adoc[leveloffset=+1]
+include::linktypes-delete.adoc[leveloffset=+1]

--- a/work-item-links/linktypes/linktypes-create.adoc
+++ b/work-item-links/linktypes/linktypes-create.adoc
@@ -1,0 +1,33 @@
+[[create-link-type]]
+= Create link type
+
+[[create-link-type-request]]
+== Request
+
+In order to create a <<link-type>> in the <<link-category>> `'test'` of a
+fictional subsystem, you would have to request it this way:
+
+[source,json]
+----
+include::examples/linktypes-create.req.txt[]
+----
+
+== Responses
+
+This section contains possible responses for a
+<<create-link-type-request,link type creation request>>.
+
+link:http://jsonapi.org/format/#crud-creating-responses-201[`201 Created`]::
+[source,json]
+----
+include::examples/linktypes-create.res.txt[]
+----
+
+These are also possible return codes:
+
+* link:http://jsonapi.org/format/#crud-creating-responses-202[`202 Accepted`]
+* link:http://jsonapi.org/format/#crud-creating-responses-204[`204 No Content`]
+* link:http://jsonapi.org/format/#crud-creating-responses-403[`403 Forbidden`]
+* link:http://jsonapi.org/format/#crud-creating-responses-404[`404 Not Found`]
+* link:http://jsonapi.org/format/#crud-creating-responses-409[`409 Conflict`]
+* link:http://jsonapi.org/format/#crud-creating-responses-other[Other Responses]

--- a/work-item-links/linktypes/linktypes-delete.adoc
+++ b/work-item-links/linktypes/linktypes-delete.adoc
@@ -1,0 +1,22 @@
+[[delete-link-type]]
+= Delete link type
+
+[[delete-link-type-request]]
+== Request
+
+In order to delete <<link-type>>, execute this request.
+
+[source]
+----
+include::examples/linktypes-delete.req.txt[]
+----
+
+== Responses
+
+These are possible return codes:
+
+* link:http://jsonapi.org/format/#crud-deleting-responses-202[`202 Accepted`]
+* link:http://jsonapi.org/format/#crud-deleting-responses-204[`204 No Content`]
+* link:http://jsonapi.org/format/#crud-deleting-responses-200[`200 OK`]
+* link:http://jsonapi.org/format/#crud-deleting-responses-404[`404 Not Found`]
+* link:http://jsonapi.org/format/#crud-deleting-responses-other[Other Responses]

--- a/work-item-links/linktypes/linktypes-read.adoc
+++ b/work-item-links/linktypes/linktypes-read.adoc
@@ -1,0 +1,22 @@
+[[read-link-type]]
+= Read link type
+
+[[read-link-type-request]]
+== Request
+
+In order to read a single <<link-type>>, execute this request.
+
+[source]
+----
+include::examples/linktypes-read-single.req.get[]
+----
+
+More information on fetching a resource please take a look at the JSON API
+section link:http://jsonapi.org/format/#fetching[here].
+
+== Responses
+
+These are possible return codes:
+
+* link:http://jsonapi.org/format/#fetching-resources-responses-200[`200 OK`]
+* link:http://jsonapi.org/format/#fetching-resources-responses-404[`404 Not Found`]

--- a/work-item-links/linktypes/linktypes-update.adoc
+++ b/work-item-links/linktypes/linktypes-update.adoc
@@ -1,0 +1,28 @@
+[[update-link-type]]
+= Update link type
+
+[[update-link-type-request]]
+== Request
+
+In order to update <<link-type>>, execute this request.
+
+[source,json]
+----
+include::examples/linktypes-update.req.txt[]
+----
+
+For more information on updating a resource and not including all attributes, 
+please take a look at the JSON API section
+link:http://jsonapi.org/format/#crud-updating-resource-attributes[here].
+
+== Responses
+
+These are possible return codes:
+
+* link:http://jsonapi.org/format/#crud-updating-responses-202[`202 Accepted`]
+* link:http://jsonapi.org/format/#crud-updating-responses-200[`200 OK`]
+* link:http://jsonapi.org/format/#crud-updating-responses-204[`204 No Content`]
+* link:http://jsonapi.org/format/#crud-updating-responses-403[`403 Forbidden`]
+* link:http://jsonapi.org/format/#crud-updating-responses-404[`404 Not Found`]
+* link:http://jsonapi.org/format/#crud-updating-responses-409[`409 Conflict`]
+* link:http://jsonapi.org/format/#crud-updating-responses-other[Other Responses]

--- a/work-item-links/part.rest.adoc
+++ b/work-item-links/part.rest.adoc
@@ -1,0 +1,83 @@
+[[rest-interface]]
+= REST interface
+
+The REST interface for work item <<link,links>> lives under its own HTTP endpoint.
+
+When we started the discussion on this topic we planned the REST endpoint to
+live under the `api/workitems/<id>/links` endpoint. At first sight, it might make
+sense to have `api/workitems/42/links` to query all <<link,links>> for the work
+item with ID `42`. But on second thought, this endpoint schema doesn't allow you
+to formulate a query for all blocked bugs because you always have a to have a
+work item ID inside of the URL.
+
+When we decided if <<link,links>> shall live under the REST endpoint `api/links`
+or `api/workitems/links`, the latter endpoint made more sense at first because
+it underlines that a <<link,link>> is meant for work items. But the downside is
+that we cannot have a work item with an ID called `links` because that would be
+addressed with `api/workitems/links`.
+
+Hence, we went with these endpoints:
+
+* `api/links`
+* `api/linktypes`
+* `api/linkcategories`
+
+NOTE: We may implement a convenience endpoint eventually that looks like
+`api/workitems/<id>/links` but it will not be the default way of dealing with
+links for the work item with ID `<id>`.
+
+The following sections deal with the specific endpoints for manipulating all
+defined resources.
+
+The table <<crud-matrix>> gives an overview of all the available actions and
+their appropriate calls to endpoints.
+
+The endpoints satisfy the JSON API specification [jsonapi-spec].
+
+[[crud-matrix]]
+.CRUD matrix
+[cols="d,d,m,m"]
+|===
+|Resource |Action |Method |Endpoint
+
+// Link categories
+
+| <<link-category>> | <<create-link-category,Create>> | POST | api/linkcategories
+| <<link-category>> | <<read-link-category,Fetch single>> | GET | api/linkcategories/<linkcategoryid>
+| <<link-category>> | Fetch all | GET | api/linkcategories 
+| <<link-category>> | <<update-link-category,Update>> | PUT | api/linkcategories/<linkcategoryid>
+
+// Link types
+
+| <<link-type>> | <<create-link-type,Create>> | POST | api/linktypes
+| <<link-type>> | <<read-link-type,Fetch single>> | GET | api/linktypes/<linktypeid>
+| <<link-type>> | Fetch all | GET | api/linktypes 
+| <<link-type>> | <<update-link-type,Update>> | PUT | api/linktypes/<linktypeid>
+
+// Links
+
+| <<link>> | <<create-link,Create>> | POST | api/links 
+| <<link>> | <<read-link,Fetch single>> | GET | api/links/<linkid>
+| <<link>> | Fetch all | GET | api/links 
+| <<link>> | <<update-link,Update>> | PUT | api/links/<linkid>
+|===
+
+IMPORTANT: TODO: Include links like `/api/links/22/linktype` in order to get the link type
+of link with ID 22
+
+In the example requests and responses we use specific UUIDs to refer to:
+
+ - a <<link-category>> (`6c5610be-30b2-4880-9fec-81e4f8e4fd76`),
+ - a <<link-type>> (`40bbdd3d-8b5d-4fd6-ac90-7236b669af04`),
+ - and a <<link>> (`c6923e37-5111-4972-8397-a0009c8425a5`).
+
+In general requests and response for CRUD operations are modeled after the
+requests and responses you can find in the JSONAPI section on
+link:http://jsonapi.org/format/#crud[CRUD].
+
+
+include::linkcategories/index.adoc[leveloffset=+1]
+
+include::linktypes/index.adoc[leveloffset=+1]
+
+include::links/index.adoc[leveloffset=+1]

--- a/work-item-links/part.storage.adoc
+++ b/work-item-links/part.storage.adoc
@@ -1,0 +1,71 @@
+[[storage]]
+= Storage
+
+[[storage-of-link-types]]
+== Storage of link types
+
+A <<link-type,link type>> needs to have an `ID` field for easy referencing. A
+`name` like i.e. `"blocker"` and `description` like `"prevents a bug from being
+closed by another bug"` makes also sense. But at the very least we must also
+specify the work item types for the <<source,source>> and the <<target,target>>.
+
+Since a bidirectional relationship can be viewed from the <<source,source>> or
+the <<target,target>>, it helps to specify words for each direction. Let's say,
+
+> a bug B1 _blocks_ a bug B2.
+
+If we put it the other way around,
+
+> bug B2 _is blocked_ by B1.
+
+We decided to include these words (_blocks_, and _blocked by_) in the
+<<link-type,link type>> and refer to them as the <<forward-name>> and
+<<reverse-name>>.
+
+NOTE: We srongly believe that it helps us with internationalization (_i18n_) in
+the long run to have english words for the <<forward-name>> and
+<<reverse-name>>. With this information we have enough information to generate
+output for a tool like link:https://en.wikipedia.org/wiki/Gettext[gettext] or
+link:https://poedit.net/[Poedit]. But for now the texts just have a descriptive
+purpose.
+
+[[example-link-type-storage-layout]]
+.Example of <<link type>> storage layout
+|===
+| ID| Name | Description | <<source-type>> | <<forward-name>> | <<target-type>> | <<reverse-name>> | <<link-category>>
+| 0| epic-user-story-link | An epic can be the parent of a user story. | system.epic | parent | system.user-story | child | system
+| 1| user-story-task-link | Tasks can be associated with a user story. | system.user-story|parent | system.task | child | system
+| 2| bug-blocker | The source bug shall prevent the target bug from being closed. | system.bug | blocks | system.bug | blocked by | system
+| 3| foo-bar | A <<link-type>> defined by the user | system.foo | ... | system.bar | ... | user
+| 4| related | ... | * | related | * | related | user
+|===
+
+[[storage-of-links]]
+== Storage of links
+
+Storing a work item <<link,link>> is straight forward, now that we've layed out the <<link-type,link types>>.
+
+[[example-link-storage-layout]]
+.Example of link storage layout
+|===
+| ID| <<link-type>> | <<source>> | <<target>> | <<link-comment>> 
+| 0| 2| 42| 333 | n/a
+|===
+
+In the table <<example-link-storage-layout>> we store a <<link,link>> between
+the <<source>> work item with ID `42` and the <<target>> work item with ID
+`333`. Note that the <<link-type>> is `2`, hence it is a `bug-blocker` (See
+table <<example-link-type-storage-layout>>) and the linked work items are bugs
+(`"system.bug"`).
+
+In other words we store the <<link>> that _bug 42_ blocks _bug 333_.
+
+[[link-validation]]
+=== Link validation
+
+On creation of a new <<link>> we must validate that the two work items to be
+linked can actually be linked. That means, a <<link-type>> must exist that has
+the proper <<source>> and <<target>> work items types specified.
+
+IMPORTANT: On the backend side we *MUST NOT* forget to check if we can do
+validation when a work item type changes.

--- a/work-item-links/validate-examples.sh
+++ b/work-item-links/validate-examples.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+# Validates the examples using an NPM package called jsaonapi-validator.
+
+#set -x
+set -e
+
+JSON_VALIDATOR_DEFAULT=~/node_modules/jsonapi-validator/bin/jsonapi-validator.js
+JSON_VALIDATOR="${JSON_VALIDATOR:-${JSON_VALIDATOR_DEFAULT}}"
+
+if [ ! -e "${JSON_VALIDATOR}" ]; then
+  echo "Cannot find the NPM program ${JSON_VALIDATOR}."
+  echo ""
+  echo "In order to install it, run \"npm i jsonapi-validator\"."
+  echo "Alternatively you can specify the JSON_VALIDATOR environment"
+  echo "varaible to point to $(basename ${JSON_VALIDATOR_DEFAULT})."
+  exit 1
+fi
+
+TEMPFILE=$(mktemp --suffix=.json)
+function cleanup() {
+  rm -f ${TEMPFILE}
+}
+trap "cleanup" EXIT
+
+find . -iregex ".*\.\(req\|res\)\.txt" | while read f
+do
+  echo -n "TESTING $f..."
+
+  if [ ! -z "$(echo $f | grep "delete")" ]; then
+    echo "IGNORING delete request" 
+    continue
+  fi
+
+  cp $f $TEMPFILE
+
+  # Strip off the HTTP header from the example
+  sed -i '1,/^$/d' ${TEMPFILE}
+
+  # Validate the file 
+  ${JSON_VALIDATOR} -f ${TEMPFILE} 1>/dev/null
+
+  if [ "$?" == 0 ]; then
+    echo "OK"
+  else
+    echo "FAILURE"
+  fi
+
+done
+


### PR DESCRIPTION
Hi @aslakknutsen , @joshuawilson , @maxandersen , @michaelkleinhenz , @tsmaeder ,

I'd be very happy if you can review my work on adding a documentation for **Work item links: Design, Storage and REST API**. As far as I know, @michaelkleinhenz needs this to write a service mock against this on the client side. _But I bet, he thought the REST API would look different :/_

I have not included the fetching of many links, linktypes, or linkcategories but from the [JSON API spec](http://jsonapi.org/format/) it should be pretty straight forward to figure out how the responses look like. I didn't want to start on this topic because it might involve some of the work outcome from @tsmaeder on pagination.

My change is best viewed in a browser when running `bundle exec jekyll serve` on your local machine because I've created many files.

All example request and response files can be verified using the supplied `work-item-links/validate-examples.sh` script. Just run it to validate that the requests and responses contain valid JSON API.

**NOTE:**
I started the documentation standalone and now integrating it into devdocs might look wrong (the TOC is put on the left side) and the headers and footers are missing. But at least you get a fixed TOC that stays in place for you to jump back and forth in the heavily linked document.

Thank you in advance for reviewing.
