### PR TITLE
Fix image links

### DIFF
--- a/_blueprints/build_concept.adoc
+++ b/_blueprints/build_concept.adoc
@@ -1,4 +1,5 @@
 = Build Concepts
+:imagesdir: images/
 
 == Goals of this Document
 


### PR DESCRIPTION
Images have been moved to `images/` directory, but links have not been updated. This patch should fix it.

cc: @michaelkleinhenz 