### PR TITLE
Makes swagger editor link importing build-spi yaml

### DIFF
--- a/design/api/build-spi/README.md
+++ b/design/api/build-spi/README.md
@@ -1,7 +1,7 @@
 [![Swagger](https://online.swagger.io/validator?url=https://github.com/tnozicka/almighty-devdoc/raw/add-build-spi-definition/design/api/build-spi/swagger.yaml)](http://online.swagger.io/validator?url=https://github.com/tnozicka/almighty-devdoc/raw/add-build-spi-definition/design/api/build-spi/swagger.yaml)
 
 # Editing
-You may use http://editor.swagger.io/ or an editor of your choise.
+You may use [http://editor.swagger.io/](http://editor.swagger.io/#/?import=https://raw.githubusercontent.com/almighty/almighty-devdoc/master/design/api/build-spi/swagger.yaml)  or any editor of your choice.
 
 # Visualization
-If you use http://editor.swagger.io/ you already see the REST API rendered as well or you can use e.g. https://github.com/swagger-api/swagger-ui
+If you use [http://editor.swagger.io/](http://editor.swagger.io/#/?import=https://raw.githubusercontent.com/almighty/almighty-devdoc/master/design/api/build-spi/swagger.yaml) you already can see the REST API rendered. Alterantively you can use e.g. https://github.com/swagger-api/swagger-ui.


### PR DESCRIPTION
When clicking on `editor.swagger.io` link user will be redirected to the editor with build-spi schema already imported. Additionally some minor wording improvements.